### PR TITLE
#22 Add global play/pause

### DIFF
--- a/custom_components/ledfx/client.py
+++ b/custom_components/ledfx/client.py
@@ -289,6 +289,12 @@ class LedFxClient:
             )
 
         return await self.request("audio/devices", Method.PUT, {"index": index})
+    
+    async def toggle_play_pause(self) -> None:
+        """toggle play/pause method.
+        """
+
+        return await self.request("virtuals", Method.PUT)
 
     async def run_scene(self, scene_id: str) -> dict:
         """scenes run method.

--- a/custom_components/ledfx/const.py
+++ b/custom_components/ledfx/const.py
@@ -19,6 +19,7 @@ PLATFORMS: Final = [
     Platform.SWITCH,
     Platform.NUMBER,
     Platform.SELECT,
+    Platform.MEDIA_PLAYER,
 ]
 
 """Diagnostic const"""

--- a/custom_components/ledfx/media_player.py
+++ b/custom_components/ledfx/media_player.py
@@ -1,0 +1,99 @@
+"""Media player component."""
+
+from __future__ import annotations
+
+from homeassistant.components.media_player import (
+    ENTITY_ID_FORMAT,
+    MediaPlayerEntity,
+    MediaPlayerEntityDescription,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import ATTR_STATE
+from .entity import LedFxEntity
+from .updater import LedFxUpdater, async_get_updater
+
+MEDIA_PLAYERS: tuple[MediaPlayerEntityDescription, ...] = (
+    MediaPlayerEntityDescription(
+        key="media_player",
+        name="LedFx media player",
+        device_class="tv",
+        entity_registry_enabled_default=True,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up LedFx media player entry.
+
+    :param hass: HomeAssistant: Home Assistant object
+    :param config_entry: ConfigEntry: Config Entry object
+    :param async_add_entities: AddEntitiesCallback: Async add callback
+    """
+
+    updater: LedFxUpdater = async_get_updater(hass, config_entry.entry_id)
+
+    entities: list[LedFxMediaPlayer] = [
+        LedFxMediaPlayer(
+            f"{config_entry.entry_id}-{description.key}",
+            description,
+            updater,
+        )
+        for description in MEDIA_PLAYERS
+    ]
+    async_add_entities(entities)
+
+
+class LedFxMediaPlayer(LedFxEntity, MediaPlayerEntity):
+    """LedFx media player entry."""
+
+    def __init__(
+        self,
+        unique_id: str,
+        description: MediaPlayerEntityDescription,
+        updater: LedFxUpdater,
+    ) -> None:
+        """Initialize media player.
+
+        :param unique_id: str: Unique ID
+        :param description: MediaPlayerEntityDescription: MediaPlayerEntityDescription object
+        :param updater: LedFxUpdater: LedFx updater object
+        """
+
+        LedFxEntity.__init__(self, unique_id, description, updater, ENTITY_ID_FORMAT)
+
+        self._supported_features = (
+            MediaPlayerEntityFeature.PLAY
+            | MediaPlayerEntityFeature.PAUSE
+        )
+
+    @property
+    def supported_features(self) -> MediaPlayerEntityFeature:
+        """Supported features."""
+        return self._supported_features
+
+    def _handle_coordinator_update(self) -> None:
+        """Update state."""
+
+        if self._updater.data.get("paused"):
+            self._attr_state = MediaPlayerState.PAUSED
+        else:
+            self._attr_state = MediaPlayerState.PLAYING
+
+        self.async_write_ha_state()
+
+    async def async_media_play(self) -> None:
+        """Play media."""
+        await self._updater.client.toggle_play_pause()
+
+    async def async_media_pause(self) -> None:
+        """Pause media."""
+        await self._updater.client.toggle_play_pause()

--- a/custom_components/ledfx/updater.py
+++ b/custom_components/ledfx/updater.py
@@ -211,6 +211,9 @@ class LedFxUpdater(DataUpdateCoordinator):
 
         self.data[ATTR_STATE] = codes.is_success(self.code)
 
+        v_response: dict = await self.client.virtuals()
+        self.data["paused"] = v_response["paused"]
+
         return self.data
 
     @cached_property


### PR DESCRIPTION
Here's a PR implementing my feature request: https://github.com/dmamontov/hass-ledfx/issues/22

I went with the addition of a media_player entity. After all, LedFx is (kind of) a media player. Thought it would make more sense to put the play & pause feature into a media_player than in a switch. Also, we could add other new features like setting the global intensity (which could be the media_player "volume". Finally, the already existing feature of switching LedFx's audio source could be implemented in an async_select_source function of the media player.

For the coding style, I went straight to the point and didn't structure as well as the existing code. Let me know if you have suggestions to improve this.

Thanks :)